### PR TITLE
Disable K8s deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,13 +49,6 @@ workflows:
             branches:
               only: trunk
           context: ghcr-ctx
-      - deploy:
-          requires:
-            - docker/publish
-          filters:
-            branches:
-              only: trunk
-          context: k8s-ctx
 
 jobs:
   deploy:


### PR DESCRIPTION
This website is moving over from a self-hosted Kubernetes cluster to Cloudflare Pages. As such, the CI deploy job is no longer needed. Cloudflare will deploy the website via a hook from GitHub. A CircleCI job will not be needed.