### PR TITLE
Temp fix the bad comment copy

### DIFF
--- a/src/hugo.yml
+++ b/src/hugo.yml
@@ -12,6 +12,9 @@ params:
   description: "My journey building Melitix Events and the struggle leading up to it."
   accentColor: "#53d769"
   subNav: "disable"
+  discourse:
+    username: "FelicianoTech"
+    url: "https://discuss.feliciano.tech/"
 
 blackfriday:
   hrefTargetBlank: true


### PR DESCRIPTION
Right now in production, the site says: "Discourse powered comments can appear here if you turn the feature on."

That message was meant for dev only. Adding these values should make that message clear even though comments still won't show up.